### PR TITLE
bugfix: Calendar Insert

### DIFF
--- a/GoogleCalendar.js
+++ b/GoogleCalendar.js
@@ -9,7 +9,7 @@ var needle = require('needle');
 
 function GoogleCalendar(access_token){
   
-  this.request  = function(type, path, params, options, body,
+  this.request  = function(type, path, params, options, body,callback) {
     var url = 'https://www.googleapis.com/calendar/v3'+path+'?access_token='+access_token;
     
     params = params || {}
@@ -132,7 +132,7 @@ Calendars.prototype.get = function(calendarId, option, callback) {
 
 Calendars.prototype.insert = function(calendar, option, callback) {
   if(!callback){ callback = option; option = {}; }
-  // Body should also reflect {summary : 'calendName'}
+  // Body should also reflect {summary : calendName}
   this.request('POST', '/calendars',  option, calendar, option, callback);
 }
 


### PR DESCRIPTION
Insert Calendar needs a body as of https://developers.google.com/google-apps/calendar/v3/reference/calendars/insert#examples | I tested it by creating a calendar. 
