### PR TITLE
Fixing list example (undefined variable)

### DIFF
--- a/example/list-example.js
+++ b/example/list-example.js
@@ -77,7 +77,7 @@ app.all('/:calendarId', function(req, res){
     
     console.log(data)
     if(data.nextPageToken){
-      google_calendar.events.list(calendarId, {maxResults:1, pageToken:data.nextPageToken}, function(err, data) {
+      gcal(accessToken).events.list(calendarId, {maxResults:1, pageToken:data.nextPageToken}, function(err, data) {
         console.log(data.items)
       })
     }


### PR DESCRIPTION
I've found this undefined variable (**google_calendar**) while studying your examples. So, it is now using "**gcal(accessToken)**" from the outer function.
Thanks for developing this node package.
