### PR TITLE
Update needle version in Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "passport": "~0.1",
     "passport-google-oauth": "~0.1",
-    "needle": "~0.5",
+    "needle": "~2.0.1",
     "express": "~3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Needle version 0.5 was causing socket hang up issues when issuing multiple calls to google calendar. Updating it to ~2.0.1 resolved the issue.